### PR TITLE
allow default title shown on the menu dropdown

### DIFF
--- a/angular-multi-select.js
+++ b/angular-multi-select.js
@@ -49,6 +49,7 @@ angular.module( 'multi-select', ['ng'] ).directive( 'multiSelect' , [ '$sce', '$
             tickProperty    : '@',
             disableProperty : '@',
             orientation     : '@',
+            defaultLabel    : '@',
             maxLabels       : '@',
             isDisabled      : '=',
             directiveId     : '@',
@@ -179,7 +180,7 @@ angular.module( 'multi-select', ['ng'] ).directive( 'multiSelect' , [ '$sce', '$
 
                 // Write label...
                 if ( $scope.selectedItems.length === 0 ) {
-                    $scope.varButtonLabel = 'None selected';
+                    $scope.varButtonLabel = ($scope.defaultLabel)? $scope.defaultLabel : 'None selected';
                 }
                 else {
                     var tempMaxLabels = $scope.selectedItems.length;


### PR DESCRIPTION
Example:  **default-label="All Genres"**

```
<div 
    multi-select 
    input-model="$scope.arrOfObjects"
    output-model="$scope.arrOfObjects2"
    button-label="property1 property2 ..."         
    item-label="property1 property2 ..." 
    tick-property="property3" 
    disable-property="property4"
    orientation="horizontal | vertical"
    selection-mode="multiple | single"
    max-labels="999"     
    directive-id="..."
    is-disabled="true | false"
    helper-elements="all none reset filter"
    on-open="$scope.functionOpen()"
    on-close="$scope.functionClose()"
    on-focus="$scope.functionFocus()"
    on-blur="$scope.functionBlur()"   
    default-label="default text"
>
</div>
```
