### PR TITLE
Allow for custom button labels

### DIFF
--- a/angular-multi-select.js
+++ b/angular-multi-select.js
@@ -57,6 +57,7 @@ angular.module( 'multi-select', ['ng'] ).directive( 'multiSelect' , [ '$sce', '$
             selectionMode   : '@',            
             selectedPrefix  : '@',
             selectedSuffix  : '@',
+            showRemaining   : '@',
                                                          
             // settings based on input model property 
             tickProperty    : '@',
@@ -493,7 +494,7 @@ angular.module( 'multi-select', ['ng'] ).directive( 'multiSelect' , [ '$sce', '$
                         }
                         var customLabel = [];
                         if ($scope.selectedPrefix) customLabel.push($scope.selectedPrefix);
-                        customLabel.push($scope.selectedItems.length);
+                        $scope.showRemaining ? customLabel.push($scope.selectedItems.length - parseInt($scope.maxLabels)) : customLabel.push($scope.selectedItems.length);
                         if ($scope.selectedSuffix) customLabel.push($scope.selectedSuffix);
 
                         if (customLabel.length > 1) {


### PR DESCRIPTION
Currently when multiple selections are made, the default message when `max-labels` is set is `...(Total 10)`. I would want it to be more flexible and have `selected-prefix` and `selected-suffix` be configurable attributes on the element.
