### PR TITLE
Allow hidden items

### DIFF
--- a/angular-multi-select.css
+++ b/angular-multi-select.css
@@ -248,6 +248,12 @@
     cursor: pointer;    
 }
 
+/* hidden class*/
+.multiSelect .hidden {
+    display: none !important;
+    visibility: hidden !important;
+}
+
 /* checkboxes currently disabled */
 .multiSelect .disabled, 
 .multiSelect .disabled:hover,

--- a/angular-multi-select.js
+++ b/angular-multi-select.js
@@ -60,6 +60,7 @@ angular.module( 'multi-select', ['ng'] ).directive( 'multiSelect' , [ '$sce', '$
             tickProperty    : '@',
             disableProperty : '@',
             groupProperty   : '@',
+            hiddenProperty  : '@',
             maxHeight       : '@',
 
             // callbacks
@@ -87,7 +88,7 @@ angular.module( 'multi-select', ['ng'] ).directive( 'multiSelect' , [ '$sce', '$
                         '</div>' +
                         '<div class="checkBoxContainer" style="{{setHeight();}}">' +
                             '<div ng-repeat="item in filteredModel | filter:removeGroupEndMarker" class="multiSelectItem"' +
-                                'ng-class="{selected: item[ tickProperty ], horizontal: orientationH, vertical: orientationV, multiSelectGroup:item[ groupProperty ], disabled:itemIsDisabled( item )}"' +
+                                'ng-class="{selected: item[ tickProperty ], horizontal: orientationH, vertical: orientationV, multiSelectGroup:item[ groupProperty ], disabled:itemIsDisabled( item ), hidden:itemIsHidden( item )}"' +
                                 'ng-click="syncItems( item, $event, $index );"' + 
                                 'ng-mouseleave="removeFocusStyle( tabIndex );">' + 
                                 '<div class="acol" ng-if="item[ spacingProperty ] > 0" ng-repeat="i in numberToArray( item[ spacingProperty ] ) track by $index">&nbsp;</div>' +              
@@ -511,6 +512,15 @@ angular.module( 'multi-select', ['ng'] ).directive( 'multiSelect' , [ '$sce', '$
                     }
                 }
                 
+            }
+            
+            //Check if the item is hidden
+            $scope.itemIsHidden = function( item ) {
+                if ( typeof attrs.hiddenProperty !== 'undefined' && item[ $scope.hiddenProperty ] === true ) {
+                    return true;
+                }else{
+                    return false;
+                }
             }
 
             // A simple function to parse the item label settings


### PR DESCRIPTION
Allow the option of have hidden items in the elements array. In my case i' using the multiselect for build a selector thats allow hide/show columns in a table/grid. The grid have hidden columns with data needed for do some magic stuff, with this extra parameter i can keep those extra columns in the array without need to pass a filtered array to the multiselect and re-build the original array using the output-model data.

I can think a few more case of use for this feature if needed. 