### PR TITLE
Add angular-multi-select.css as an main artifact in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,8 @@
     "name"      : "isteven-angular-multiselect",
     "version"   : "v2.0.1",
     "main"      : [
-        "angular-multi-select.js"
+        "angular-multi-select.js",
+        "angular-multi-select.css"
     ],
     "ignore"    : [
         ".git",


### PR DESCRIPTION
Without this, build tools like [main-bower-files](https://github.com/ck86/main-bower-files) and [wiredep](https://github.com/taptapship/wiredep) can't do their magic.
