### PR TITLE
Fix of "error:isecdom" with angularjs 1.3.0

### DIFF
--- a/angular-multi-select.js
+++ b/angular-multi-select.js
@@ -560,7 +560,7 @@ angular.module( 'multi-select', ['ng'] ).directive( 'multiSelect' , [ '$sce', '$
                     $scope.removeFocusStyle( $scope.tabIndex );
 
                     // close callback
-                    $scope.onClose( { data: element } );
+                    $scope.onClose( { data: $scope.selectedItems } );
                     return true;
                 }                                
 
@@ -578,7 +578,7 @@ angular.module( 'multi-select', ['ng'] ).directive( 'multiSelect' , [ '$sce', '$
                     $scope.removeFocusStyle( $scope.tabIndex );
 
                     // close callback
-                    $scope.onClose( { data: element } );
+                    $scope.onClose( { data: $scope.selectedItems } );
                 } 
                 // open
                 else                 
@@ -616,7 +616,7 @@ angular.module( 'multi-select', ['ng'] ).directive( 'multiSelect' , [ '$sce', '$
                     }                       
 
                     // open callback
-                    $scope.onOpen( { data: element } );
+                    $scope.onOpen( { data: $scope.selectedItems } );
                 }                            
             }
             
@@ -636,7 +636,7 @@ angular.module( 'multi-select', ['ng'] ).directive( 'multiSelect' , [ '$sce', '$
                 
                 // close callback                
                 $timeout( function() {
-                    $scope.onClose( { data: element } );
+                    $scope.onClose( { data: $scope.selectedItems } );
                 }, 0 );
             }
    


### PR DESCRIPTION
Hi
Respect and thanks for your very nice multiselect component. I use it and its fine.
Recently I noticed an error in console - "error:isecdom"  ( https://docs.angularjs.org/error/$parse/isecdom ).
The reason was change of angularjs version from 1.2.9 to 1.3.0, where was added the restriction on DOM nodes.
It happens on opening and closing the multi-select, when you define on-open, on-close.
With angularjs 1.2.X there issn't such error.
The fix, that works for me is in commit - replacing the DOM element with selected items.
For me were the selected items the usable argument.
I don't know if it's according to your intentions with the resulting arguments in onOpen / onClose, but this is one of the ways.

To try it see the console log in http://plnkr.co/edit/3ypYOAo1BPxRPWNnqpCE?p=preview and click the multiselect,
and in index.html you can switch the comments on angular version and multiselect.fix version files.