### PR TITLE
use css instead of spaces for label padding

### DIFF
--- a/angular-multi-select.css
+++ b/angular-multi-select.css
@@ -190,6 +190,11 @@
     min-width:278px;
 }
 
+.multiSelect .multiSelectLabel {
+    display: inline-block;
+    padding-right: 24px;
+}
+
 /* Item labels: selected - Enable this if you want to apply styling on selected items */
 .multiSelect .multiSelectItem:not(.multiSelectGroup).selected
 {

--- a/angular-multi-select.js
+++ b/angular-multi-select.js
@@ -92,12 +92,11 @@ angular.module( 'multi-select', ['ng'] ).directive( 'multiSelect' , [ '$sce', '$
                                 'ng-mouseleave="removeFocusStyle( tabIndex );">' + 
                                 '<div class="acol" ng-if="item[ spacingProperty ] > 0" ng-repeat="i in numberToArray( item[ spacingProperty ] ) track by $index">&nbsp;</div>' +              
                                 '<div class="acol">' +
-                                    '<label>' +
+                                    '<label class="multiSelectLabel">' +
                                         '<input class="checkbox focusable" type="checkbox" ng-disabled="itemIsDisabled( item )" ng-checked="item[ tickProperty ]" ng-click="syncItems( item, $event, $index )" />' +
                                         '<span ng-class="{disabled:itemIsDisabled( item )}" ng-bind-html="writeLabel( item, \'itemLabel\' )"></span>' +
                                     '</label>' +                                
                                 '</div>' +
-                                '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;' + 
                                 '<span class="tickMark" ng-if="item[ groupProperty ] !== true && item[ tickProperty ] === true">&#10004;</span>' +
                             '</div>' +
                         '</div>' +
@@ -238,7 +237,7 @@ angular.module( 'multi-select', ['ng'] ).directive( 'multiSelect' , [ '$sce', '$
                             if ( attrs.helperElements && $scope.helperElements.toUpperCase().indexOf( 'FILTER' ) >= 0 ) {
                                 return true;
                             }
-                            break;                    
+                            break;
                         default:                                         
                             break;
                     }                    


### PR DESCRIPTION
The &nbsp; spacing causes problems when CSS is used to limit the multiselect width. The spaces cause lines to wrap unnecessarily. Using padding avoids this and keeps your markup cleaner.
