### PR TITLE
Don't access filtered items if there are none left.

### DIFF
--- a/isteven-multi-select.js
+++ b/isteven-multi-select.js
@@ -299,7 +299,11 @@ angular.module( 'isteven-multi-select', ['ng'] ).directive( 'istevenMultiSelect'
 
             // List all the input elements.
             // This function will be called everytime the filter is updated. Not good for performance, but oh well..
-            $scope.getFormElements = function() {                                     
+            $scope.getFormElements = function() {
+                if (!element.children().children().next().children().children().next()[ 0 ]) {
+                  return; // filter leaves an empty list
+                }
+
                 formElements = [];
                 // Get helper - select & reset buttons
                 var selectButtons = element.children().children().next().children().children()[ 0 ].getElementsByTagName( 'button' );


### PR DESCRIPTION
Without this fix an exception is thrown when a string is typed into the filter that does not exist in any of the input-items.

The debug console will show the following message:

```
 TypeError: Cannot read property 'getElementsByTagName' of undefined
    at Scope.link.$scope.getFormElements (isteven-multi-select.js:307)
    at isteven-multi-select.js:271
    at angular.js:16223
    at completeOutstandingRequest (angular.js:4905)
    at angular.js:5285
```

i.e. creating the inputField array fails.