### PR TITLE
allow literal chars in button and item labels

### DIFF
--- a/isteven-multi-select.js
+++ b/isteven-multi-select.js
@@ -582,7 +582,8 @@ angular.module( 'isteven-multi-select', ['ng'] ).directive( 'istevenMultiSelect'
                 angular.forEach( temp, function( value, key ) {                    
                     item[ value ] && ( label += '&nbsp;' + value.split( '.' ).reduce( function( prev, current ) {
                         return prev[ current ]; 
-                    }, item ));        
+                    }, item ));       
+		    !item[ value ] && (label += value); 
                 });
                 if ( type.toUpperCase() === 'BUTTONLABEL' ) {
                     return label;


### PR DESCRIPTION
This allows you to put literal characters into your labels. Then you can do things like:

item-label="lastname , firstname"

Anything that is not matched as a a property after splitting on the space separator is assumed to be literals and included into the label.