### PR TITLE
Update max-labels doc to reflect 3.0.0 changes

### DIFF
--- a/doc/views/configs-options.htm
+++ b/doc/views/configs-options.htm
@@ -174,8 +174,8 @@
             With the input-model above, 
         </p>          
         <ul>
-            <li><code>max-labels="1"</code> will display: "Bruce Wayne, ... (Total: 2)" on the button.</li>
-            <li><code>max-labels="0"</code> will display: "(Total: 2)" on the button.</li>
+            <li><code>max-labels="1"</code> will display: "Bruce Wayne, ... (2)" on the button.</li>
+            <li><code>max-labels="0"</code> will display: "(2)" on the button.</li>
         </ul>
             
         <h5>is-disabled</h5>


### PR DESCRIPTION
[It's documented](http://isteven.github.io/angular-multi-select/#/configs-options) that "max-labels" will include a message like "(Total: 24)"; however, the "Total: " part was removed (intentionally?) in the [v3.0.0 commit](https://github.com/isteven/angular-multi-select/commit/a0f4fd6a7da66d406658aa22e4768fd8d10ed3a9#diff-c6c6ccb3d0be68a66a14b7f94b80537aL492).
