### PR TITLE
Fix to prevent unbinding of output model

### DIFF
--- a/isteven-multi-select.js
+++ b/isteven-multi-select.js
@@ -469,7 +469,11 @@ angular.module( 'isteven-multi-select', ['ng'] ).directive( 'istevenMultiSelect'
             // update $scope.outputModel
             $scope.refreshOutputModel = function() {            
                 
-                $scope.outputModel  = [];
+                if ($scope.outputModel) {
+		    $scope.outputModel.length = 0;
+		} else {
+		    $scope.outputModel = [];
+                }
                 var 
                     outputProps     = [],
                     tempObj         = {};


### PR DESCRIPTION
By simply resetting the outputModel to a new array, some callbacks like the onSelectAll/onSelectNone callbacks are fired before the outputModel is actually updated/propagated. This prevents that. 

