### PR TITLE
Making the itemLabel and buttonLabel properties templateable

### DIFF
--- a/isteven-multi-select.js
+++ b/isteven-multi-select.js
@@ -578,13 +578,17 @@ angular.module( 'isteven-multi-select', ['ng'] ).directive( 'istevenMultiSelect'
             $scope.writeLabel = function( item, type ) {
                 
                 // type is either 'itemLabel' or 'buttonLabel'
-                var temp    = attrs[ type ].split( ' ' );                    
-                var label   = '';                
+                var temp    = attrs[ type].match( /\w+|[^\w]/g );
+                var label   = '';
 
-                angular.forEach( temp, function( value, key ) {                    
-                    item[ value ] && ( label += '&nbsp;' + value.split( '.' ).reduce( function( prev, current ) {
-                        return prev[ current ]; 
-                    }, item ));        
+                angular.forEach( temp, function( value, key ) {
+                    if (item[ value ]) {
+                        label += value.split( '.' ).reduce( function( prev, current ) {
+                                    return prev[ current ];
+                                }, item )
+                    } else {
+                        label += value;
+                    }
                 });
                 
                 if ( type.toUpperCase() === 'BUTTONLABEL' ) {                    


### PR DESCRIPTION
Rather than just assuming each group of characters between spaces is a property of the model, I've made it iterate over every group of [\w] characters or [^\w] characters. If a character group is a property on the model, then it'll append the value of that property in the model, otherwise it just output the group of characters.

So if your your model looks like:

    { description: "Thing1", code: "1" }

You can set the itemLabel property to:

    itemLabel="description (code)"

And the itemLabel will be "Thing1 (1)"