### PR TITLE
#300 Introduce a counterpart "All Selected" to "None Selected" 

### DIFF
--- a/doc/views/configs-options.htm
+++ b/doc/views/configs-options.htm
@@ -257,7 +257,7 @@
         <h5>translation</h5> <span class="label label-warning">New! v3.0.0</span>
         <p>
             Use custom text on the helper elements. You can use different text or other languages. If you use it, 
-            you need to define ALL five of the labels here, or they will show "undefined".
+            you only need to define labels you want to override the default value for.
         </p>
         <p>        
             <span class="inlineTitle">Type</span>: $scope object<br />
@@ -274,7 +274,18 @@
     nothingSelected : "Nothing is selected"         //default-label is deprecated and replaced with this.
 }</code></pre>
         </p>
-            
+        
+        <h5>show-all-selected</h5>
+        <p>
+            If set to true, the button will show "All Selected" (or the string you defined in the translation) whenever all elements of the inputModel are selected.
+            If set to false, all elements will be explicitly listed.
+        </p>
+        <p>
+            <span class="inlineTitle">Type</span>: $scope boolean expression<br />
+            <span class="inlineTitle">Default value</span>: false<br />
+            <span class="inlineTitle">Example</span>: <code>&lt;div isteven-multi-select ... show-all-selected="true"&gt;&lt;/div&gt;</code>.
+        </p>
+
         <h5>on-open</h5>
         <p>
             A $scope function to call on multi-select open. You need to define this function in your controller.

--- a/isteven-multi-select.js
+++ b/isteven-multi-select.js
@@ -965,7 +965,7 @@ angular.module( 'isteven-multi-select', ['ng'] ).directive( 'istevenMultiSelect'
                 reset: 'Reset',
                 search: 'Search...',
                 nothingSelected: 'None Selected',
-                allSelected: "All Selected"
+                allSelected: 'All Selected'
             };
 
             if ( typeof attrs.translation !== 'undefined' )

--- a/isteven-multi-select.js
+++ b/isteven-multi-select.js
@@ -46,6 +46,7 @@ angular.module( 'isteven-multi-select', ['ng'] ).directive( 'istevenMultiSelect'
 
             // settings based on attribute
             isDisabled      : '=',
+            showAllSelected : '=',
 
             // callbacks
             onClear         : '&',  
@@ -522,6 +523,9 @@ angular.module( 'isteven-multi-select', ['ng'] ).directive( 'istevenMultiSelect'
                     // https://github.com/isteven/angular-multi-select/pull/19                    
                     $scope.varButtonLabel = $scope.lang.nothingSelected;
                 }
+                else if ($scope.showAllSelected && $scope.outputModel.length === $scope.inputModel.length) {
+                    $scope.varButtonLabel = $scope.lang.allSelected;
+                }
                 else {                
                     var tempMaxLabels = $scope.outputModel.length;
                     if ( typeof attrs.maxLabels !== 'undefined' && attrs.maxLabels !== '' ) {
@@ -948,21 +952,26 @@ angular.module( 'isteven-multi-select', ['ng'] ).directive( 'istevenMultiSelect'
             // this one is for the selected items
             $scope.icon.tickMark   = '&#10003;';    // a tick icon 
 
+            var translation = { // default strings
+                selectAll: 'Select All',
+                selectNone: 'Select None',
+                reset: 'Reset',
+                search: 'Search...',
+                nothingSelected: 'None Selected',
+                allSelected: "All Selected"
+            };
+
+            if ( typeof attrs.translation !== 'undefined' )
+                angular.extend( translation, $scope.translation );
+
             // configurable button labels                       
-            if ( typeof attrs.translation !== 'undefined' ) {
-                $scope.lang.selectAll       = $sce.trustAsHtml( $scope.icon.selectAll  + '&nbsp;&nbsp;' + $scope.translation.selectAll );
-                $scope.lang.selectNone      = $sce.trustAsHtml( $scope.icon.selectNone + '&nbsp;&nbsp;' + $scope.translation.selectNone );
-                $scope.lang.reset           = $sce.trustAsHtml( $scope.icon.reset      + '&nbsp;&nbsp;' + $scope.translation.reset );
-                $scope.lang.search          = $scope.translation.search;                
-                $scope.lang.nothingSelected = $sce.trustAsHtml( $scope.translation.nothingSelected );                
-            }
-            else {
-                $scope.lang.selectAll       = $sce.trustAsHtml( $scope.icon.selectAll  + '&nbsp;&nbsp;Select All' );                
-                $scope.lang.selectNone      = $sce.trustAsHtml( $scope.icon.selectNone + '&nbsp;&nbsp;Select None' );
-                $scope.lang.reset           = $sce.trustAsHtml( $scope.icon.reset      + '&nbsp;&nbsp;Reset' );
-                $scope.lang.search          = 'Search...';
-                $scope.lang.nothingSelected = 'None Selected';                
-            }
+            $scope.lang.selectAll       = $sce.trustAsHtml( $scope.icon.selectAll  + '&nbsp;&nbsp;' + translation.selectAll );
+            $scope.lang.selectNone      = $sce.trustAsHtml( $scope.icon.selectNone + '&nbsp;&nbsp;' + translation.selectNone );
+            $scope.lang.reset           = $sce.trustAsHtml( $scope.icon.reset      + '&nbsp;&nbsp;' + translation.reset );
+            $scope.lang.search          = translation.search;                
+            $scope.lang.nothingSelected = $sce.trustAsHtml( translation.nothingSelected );                
+            $scope.lang.allSelected     = $sce.trustAsHtml( translation.allSelected );
+
             $scope.icon.tickMark = $sce.trustAsHtml( $scope.icon.tickMark );
                 
             // min length of keyword to trigger the filter function

--- a/isteven-multi-select.js
+++ b/isteven-multi-select.js
@@ -516,14 +516,21 @@ angular.module( 'isteven-multi-select', ['ng'] ).directive( 'istevenMultiSelect'
             $scope.refreshButton = function() {
 
                 $scope.varButtonLabel   = '';                
-                var ctr                 = 0;                  
+                var ctr                 = 0;
+                var itemCount           = 0;
+
+                angular.forEach($scope.inputModel, function(value, key) {
+                    if (typeof value !== 'undefined' && typeof value[attrs.tickProperty] !== 'undefined') {
+                        itemCount++;
+                    }
+                });
 
                 // refresh button label...
                 if ( $scope.outputModel.length === 0 ) {
                     // https://github.com/isteven/angular-multi-select/pull/19                    
                     $scope.varButtonLabel = $scope.lang.nothingSelected;
                 }
-                else if ($scope.showAllSelected && $scope.outputModel.length === $scope.inputModel.length) {
+                else if ( $scope.showAllSelected && $scope.outputModel.length === itemCount ) {
                     $scope.varButtonLabel = $scope.lang.allSelected;
                 }
                 else {                


### PR DESCRIPTION
Provides the enhancement suggested in issue #300.

If the attribute *show-all-selected* is set to true, the button will show "All Selected" (or the translated string) if all items are ticked.

I also made the *translate* attribute more flexible. It is now sufficient to define the labels you actually want to override.