### PR TITLE
No focus on first item if there is no filter control

### DIFF
--- a/isteven-multi-select.js
+++ b/isteven-multi-select.js
@@ -666,19 +666,7 @@ angular.module( 'isteven-multi-select', ['ng'] ).directive( 'istevenMultiSelect'
                         $scope.tabIndex = $scope.tabIndex + helperItemsLength - 2;
                         // blur button in vain
                         angular.element( element ).children()[ 0 ].blur();
-                    }
-                    // if there's no filter then just focus on the first checkbox item
-                    else {                  
-                        if ( !$scope.isDisabled ) {                        
-                            $scope.tabIndex = $scope.tabIndex + helperItemsLength;
-                            if ( $scope.inputModel.length > 0 ) {
-                                formElements[ $scope.tabIndex ].focus();
-                                $scope.setFocusStyle( $scope.tabIndex );
-                                // blur button in vain
-                                angular.element( element ).children()[ 0 ].blur();
-                            }                            
-                        }
-                    }                          
+                    }                
 
                     // open callback
                     $scope.onOpen();


### PR DESCRIPTION
If there is no filter control, the focus is deliberately set on the first list item. I believe this behavior is unexpected for the user. It makes the first list item look highlighted and special, or worse selected, where it is really not. Then, wehen the user hovers the mouse over the popup the focus jumps anyway.

I think it's better to just leave the items unfocused no matter if the filter control is present or not.