### PR TITLE
Removed spaces in `:not(.reset)`

### DIFF
--- a/isteven-multi-select.css
+++ b/isteven-multi-select.css
@@ -127,7 +127,7 @@
     float: right;
 }
 
-.multiSelect .helperButton:not( .reset ) {
+.multiSelect .helperButton:not(.reset) {
     margin-right: 4px;    
 }
 


### PR DESCRIPTION
Chrome doesn't like spaces in `:not( .reset )`.
Didn't test it in other browsers, but there's no point in using spaces here anyway.
