### PR TITLE
Treat label attributes as ordinary angular properties

### DIFF
--- a/isteven-multi-select.js
+++ b/isteven-multi-select.js
@@ -583,16 +583,19 @@ angular.module( 'isteven-multi-select', ['ng'] ).directive( 'istevenMultiSelect'
                 var label;
                 if ( type.toUpperCase() === 'BUTTONLABEL' ) {
                     label = $scope.buttonLabel( item );
-                    return label;
                 }
-
-                if ( attrs.groupProperty !== 'undefined' && typeof item[ attrs.groupProperty ] !== 'undefined' ) {
+                else if ( attrs.groupProperty !== 'undefined' && typeof item[ attrs.groupProperty ] !== 'undefined' ) {
                     label = $scope.groupLabel( item );
                 }
                 else {
                     label = $scope.itemLabel( item );
                 }
-                return $sce.trustAsHtml( label );
+
+                if ( angular.isArray( label ) ) {
+                    label = label.join( "&nbsp;" );
+                }
+
+                return type.toUpperCase() === 'BUTTONLABEL' ? label : $sce.trustAsHtml( label );
             }
 
             // UI operations to show/hide checkboxes based on click event..

--- a/isteven-multi-select.js
+++ b/isteven-multi-select.js
@@ -46,6 +46,9 @@ angular.module( 'isteven-multi-select', ['ng'] ).directive( 'istevenMultiSelect'
 
             // settings based on attribute
             isDisabled      : '=',
+            itemLabel       : '&',
+            buttonLabel     : '&',
+            groupLabel      : '&',
 
             // callbacks
             onClear         : '&',  
@@ -63,7 +66,7 @@ angular.module( 'isteven-multi-select', ['ng'] ).directive( 'istevenMultiSelect'
         
         /* 
          * The rest are attributes. They don't need to be parsed / binded, so we can safely access them by value.
-         * - buttonLabel, directiveId, helperElements, itemLabel, maxLabels, orientation, selectionMode, minSearchLength,
+         * - directiveId, helperElements, maxLabels, orientation, selectionMode, minSearchLength,
          *   tickProperty, disableProperty, groupProperty, searchProperty, maxHeight, outputProperties
          */
                                                          
@@ -575,23 +578,22 @@ angular.module( 'isteven-multi-select', ['ng'] ).directive( 'istevenMultiSelect'
             }
 
             // A simple function to parse the item label settings. Used on the buttons and checkbox labels.
-            $scope.writeLabel = function( item, type ) {
-                
-                // type is either 'itemLabel' or 'buttonLabel'
-                var temp    = attrs[ type ].split( ' ' );                    
-                var label   = '';                
+            $scope.writeLabel = function ( item, type ) {
 
-                angular.forEach( temp, function( value, key ) {                    
-                    item[ value ] && ( label += '&nbsp;' + value.split( '.' ).reduce( function( prev, current ) {
-                        return prev[ current ]; 
-                    }, item ));        
-                });
-                
-                if ( type.toUpperCase() === 'BUTTONLABEL' ) {                    
+                var label;
+                if ( type.toUpperCase() === 'BUTTONLABEL' ) {
+                    label = $scope.buttonLabel( item );
                     return label;
                 }
+
+                if ( attrs.groupProperty !== 'undefined' && typeof item[ attrs.groupProperty ] !== 'undefined' ) {
+                    label = $scope.groupLabel( item );
+                }
+                else {
+                    label = $scope.itemLabel( item );
+                }
                 return $sce.trustAsHtml( label );
-            }                                
+            }
 
             // UI operations to show/hide checkboxes based on click event..
             $scope.toggleCheckboxes = function( e ) {                                    
@@ -666,19 +668,7 @@ angular.module( 'isteven-multi-select', ['ng'] ).directive( 'istevenMultiSelect'
                         $scope.tabIndex = $scope.tabIndex + helperItemsLength - 2;
                         // blur button in vain
                         angular.element( element ).children()[ 0 ].blur();
-                    }
-                    // if there's no filter then just focus on the first checkbox item
-                    else {                  
-                        if ( !$scope.isDisabled ) {                        
-                            $scope.tabIndex = $scope.tabIndex + helperItemsLength;
-                            if ( $scope.inputModel.length > 0 ) {
-                                formElements[ $scope.tabIndex ].focus();
-                                $scope.setFocusStyle( $scope.tabIndex );
-                                // blur button in vain
-                                angular.element( element ).children()[ 0 ].blur();
-                            }                            
-                        }
-                    }                          
+                    }                
 
                     // open callback
                     $scope.onOpen();

--- a/isteven-multi-select.js
+++ b/isteven-multi-select.js
@@ -668,7 +668,19 @@ angular.module( 'isteven-multi-select', ['ng'] ).directive( 'istevenMultiSelect'
                         $scope.tabIndex = $scope.tabIndex + helperItemsLength - 2;
                         // blur button in vain
                         angular.element( element ).children()[ 0 ].blur();
-                    }                
+                    }
+                    // if there's no filter then just focus on the first checkbox item
+                    else {                  
+                        if ( !$scope.isDisabled ) {                        
+                            $scope.tabIndex = $scope.tabIndex + helperItemsLength;
+                            if ( $scope.inputModel.length > 0 ) {
+                                formElements[ $scope.tabIndex ].focus();
+                                $scope.setFocusStyle( $scope.tabIndex );
+                                // blur button in vain
+                                angular.element( element ).children()[ 0 ].blur();
+                            }                            
+                        }
+                    }                          
 
                     // open callback
                     $scope.onOpen();

--- a/isteven-multi-select.js
+++ b/isteven-multi-select.js
@@ -592,7 +592,7 @@ angular.module( 'isteven-multi-select', ['ng'] ).directive( 'istevenMultiSelect'
                 }
 
                 if ( angular.isArray( label ) ) {
-                    label = label.join( "&nbsp;" );
+                    label = label.filter(function( value ) { return value; }).join( "&nbsp;" );
                 }
 
                 return type.toUpperCase() === 'BUTTONLABEL' ? label : $sce.trustAsHtml( label );


### PR DESCRIPTION
So far *item-label* and *button-label* followed a special space-delimited syntax. I changed them to be normal angular attributes which makes it both more powerful, and more natural for an angular programmer. The key is that the expressions are evaluated with the input-model's respective item as their context.

Before:
`<isteven-multi-select ... item-label="prop1 prop2 prop3" />`
After (to achieve same behavior):
`<isteven-multi-select ... item-label="prop1 + ' ' + prop2 + ' ' + prop3" />`
or with the convenience method of returning an array:
`<isteven-multi-select ... item-label="[prop1, prop2, prop3]" />`

The real benefit is that you can now do things like using different delimeters:
`<isteven-multi-select ... item-label="prop1 + '/' + prop2 + ': ' + prop3" />`
or advanced expressions:
`<isteven-multi-select ... item-label="prop1.fun(prop2) + ' - ' + (prop3.sub.sub+1)" />`

I also added a new attribute *group-label* so it is easily possible to specify a different visual representation for groups:
`<isteven-multi-select ... item-label="[key, name]" button-label="key" group-label="'-' + name + '-'" />`