### PR TITLE
Added a prefill for dropdown

### DIFF
--- a/isteven-multi-select.js
+++ b/isteven-multi-select.js
@@ -43,6 +43,8 @@ angular.module( 'isteven-multi-select', ['ng'] ).directive( 'istevenMultiSelect'
             // models
             inputModel      : '=',
             outputModel     : '=',
+            prefillModel    : '=',
+            prefillMatchProperty    : '@',
 
             // settings based on attribute
             isDisabled      : '=',
@@ -999,12 +1001,42 @@ angular.module( 'isteven-multi-select', ['ng'] ).directive( 'istevenMultiSelect'
                     $scope.refreshOutputModel();                
                     $scope.refreshButton();                                                                                                                 
                 }
-            });                        
+            });
+
+            // this watch is for pre-fill of the dropdown
+            // it can deal with either arrays or single values
+            $scope.$watch( 'prefillModel' , function( newVal ) {
+                if(angular.isArray($scope.prefillModel)) {
+                    angular.forEach( $scope.prefillModel, function(prefillValue) {
+                        angular.forEach( $scope.inputModel, function(inputModel) {
+                            if (prefillValue === inputModel[$scope.prefillMatchProperty]) {
+                                inputModel[$scope.tickProperty] = true;
+                            }
+                            else if (prefillValue[$scope.prefillMatchProperty] === inputModel[$scope.prefillMatchProperty]) {
+                                angular.forEach( $scope.inputModel, function(resetInputModel) {
+                                    resetInputModel[$scope.tickProperty] = false;
+                                });
+                                inputModel[$scope.tickProperty] = true;
+                            }
+                        });
+                    });
+                }
+                else if($scope.prefillModel) {
+                    angular.forEach( $scope.inputModel, function(inputModel) {
+                        if ($scope.prefillModel === inputModel[$scope.prefillMatchProperty]) {
+                            angular.forEach( $scope.inputModel, function(resetInputModel) {
+                                resetInputModel[$scope.tickProperty] = false;
+                            });
+                            inputModel[$scope.tickProperty] = true;
+                        }
+                    });
+                }
+            });
 
             // watch for changes in directive state (disabled or enabled)
             $scope.$watch( 'isDisabled' , function( newVal ) {         
                 $scope.isDisabled = newVal;                               
-            });            
+            });
             
             // this is for touch enabled devices. We don't want to hide checkboxes on scroll. 
             var onTouchStart = function( e ) { 


### PR DESCRIPTION
example in html
<div
            isteven-multi-select
            input-model="index.certificateGranting"
            output-model="index.selectedCert"
            prefill-model="index.filtersFromServer.certificateGranting"
            prefill-match-property="value"
            button-label="label"
            item-label="label"
            tick-property="ticked"
</div>

if prefill model items match any values in index.certificateGranting.value it well become ticked
So for example in our index controller we have a certificateGranting in our controller
this.certificateGranting = [
            {value: 'All', label: 'All', ticked: true},
            {value: 'Y', label: 'Yes', ticked: false},
            {value: 'N', label: 'No', ticked: false}
        ];

and our value after getting from a angular service for index.filtersFromServer.certificateGranting
this.filtersFromServer.certificateGranting = ['Y']
or it can just be a string: this.filtersFromServer.certificateGranting = 'Y'

Y will now be ticked. All without having to loop and go through each value to see if it matches in your controller!