### PR TITLE
fix: label displays exackly whats in item-label attribute instead of model value

### DIFF
--- a/isteven-multi-select.js
+++ b/isteven-multi-select.js
@@ -582,10 +582,8 @@ angular.module( 'isteven-multi-select', ['ng'] ).directive( 'istevenMultiSelect'
                 var label   = '';                
 
                 angular.forEach( temp, function( value, key ) {                    
-                    item[ value ] && ( label += '&nbsp;' + value.split( '.' ).reduce( function( prev, current ) {
-                        return prev[ current ]; 
-                    }, item ));        
-                });
+                    item[ value ] && ( label += '&nbsp;' + item[value]);
+				});
                 
                 if ( type.toUpperCase() === 'BUTTONLABEL' ) {                    
                     return label;


### PR DESCRIPTION
I couldn't make it work without those changes. I use angular 1.3.15 . Here is how i used it.
```html
		<div     
			isteven-multi-select
			input-model="facilities"
			output-model="selectedFacilities"
			button-label="name"
			item-label="name"
			tick-property="selected"
			group-property="msGroup"
			orientation="horizontal"
			max-labels="0"
			translation="multi_select_translation"
		>
```
