### PR TITLE
New customization options for when there are more than max-labels items

### DIFF
--- a/doc/views/configs-options.htm
+++ b/doc/views/configs-options.htm
@@ -16,7 +16,8 @@
     orientation="horizontal | vertical"
     selection-mode="multiple | single"
     max-labels="999"     
-    show-counter="true"
+    show-counter="true | false"
+    more-text="string"
     directive-id="..."
     is-disabled="true | false"
     helper-elements="all none reset filter"
@@ -186,6 +187,16 @@
         <p>
             <span class="inlineTitle">Type</span>: Boolean-parseable string ("true" or "false")<br />
             <span class="inlineTitle">Default value</span>: "true"<br />
+        </p>
+
+        <h5>more-text</h5>
+        <p>
+            Text to show after the items in the dropdown button if there are
+            more items than allowed by max-labels.
+        </p>
+        <p>
+            <span class="inlineTitle">Type</span>: String<br />
+            <span class="inlineTitle">Default value</span>: ", ..."<br />
         </p>
 
         <h5>is-disabled</h5>

--- a/doc/views/configs-options.htm
+++ b/doc/views/configs-options.htm
@@ -16,6 +16,7 @@
     orientation="horizontal | vertical"
     selection-mode="multiple | single"
     max-labels="999"     
+    show-counter="true"
     directive-id="..."
     is-disabled="true | false"
     helper-elements="all none reset filter"
@@ -177,7 +178,16 @@
             <li><code>max-labels="1"</code> will display: "Bruce Wayne, ... (2)" on the button.</li>
             <li><code>max-labels="0"</code> will display: "(2)" on the button.</li>
         </ul>
-            
+
+        <h5>show-counter</h5>
+        <p>
+            To show the counter in the dropdown button if there are more items than allowed by max-labels.
+        </p>
+        <p>
+            <span class="inlineTitle">Type</span>: Boolean-parseable string ("true" or "false")<br />
+            <span class="inlineTitle">Default value</span>: "true"<br />
+        </p>
+
         <h5>is-disabled</h5>
         <p>
             Will disable or enable all checkboxes except stated otherwise in "disable-property" above.

--- a/isteven-multi-select.js
+++ b/isteven-multi-select.js
@@ -64,7 +64,7 @@ angular.module( 'isteven-multi-select', ['ng'] ).directive( 'istevenMultiSelect'
         /* 
          * The rest are attributes. They don't need to be parsed / binded, so we can safely access them by value.
          * - buttonLabel, directiveId, helperElements, itemLabel, maxLabels, orientation, selectionMode, minSearchLength,
-         *   tickProperty, disableProperty, groupProperty, searchProperty, maxHeight, outputProperties
+         *   tickProperty, disableProperty, groupProperty, searchProperty, maxHeight, outputProperties, showCounter
          */
                                                          
          templateUrl: 
@@ -550,7 +550,11 @@ angular.module( 'isteven-multi-select', ['ng'] ).directive( 'istevenMultiSelect'
                         if (tempMaxLabels > 0) {
                             $scope.varButtonLabel += ', ... ';
                         }
-                        $scope.varButtonLabel += '(' + $scope.outputModel.length + ')';                        
+
+                        // Default showCounter to true
+                        if ( typeof attrs.showCounter === 'undefined' || attrs.showCounter === 'true' ) {
+                            $scope.varButtonLabel += '(' + $scope.outputModel.length + ')';
+                        }
                     }
                 }
                 $scope.varButtonLabel = $sce.trustAsHtml( $scope.varButtonLabel + '<span class="caret"></span>' );                

--- a/isteven-multi-select.js
+++ b/isteven-multi-select.js
@@ -61,12 +61,13 @@ angular.module( 'isteven-multi-select', ['ng'] ).directive( 'istevenMultiSelect'
             translation     : '='   
         },
         
-        /* 
+        /*
          * The rest are attributes. They don't need to be parsed / binded, so we can safely access them by value.
          * - buttonLabel, directiveId, helperElements, itemLabel, maxLabels, orientation, selectionMode, minSearchLength,
-         *   tickProperty, disableProperty, groupProperty, searchProperty, maxHeight, outputProperties, showCounter
+         *   tickProperty, disableProperty, groupProperty, searchProperty, maxHeight, outputProperties, showCounter,
+         *   moreText
          */
-                                                         
+
          templateUrl: 
             'isteven-multi-select.htm',                            
 
@@ -548,7 +549,11 @@ angular.module( 'isteven-multi-select', ['ng'] ).directive( 'istevenMultiSelect'
                     if ( $scope.more === true ) {
                         // https://github.com/isteven/angular-multi-select/pull/16
                         if (tempMaxLabels > 0) {
-                            $scope.varButtonLabel += ', ... ';
+                            if ( typeof attrs.moreText !== 'undefined' ) {
+                                $scope.varButtonLabel += attrs.moreText;
+                            } else {
+                                $scope.varButtonLabel += ', ...';
+                            }
                         }
 
                         // Default showCounter to true


### PR DESCRIPTION
I needed to have some extra control over text in the dropdown when there are more than `max-labels` items, so I made the following changes:

* Make the ellipsis after the items customizable with the attribute `more-text`, so instead of "foo, bar, ... (5)" you can have "foo, bar (CLICK FOR MORE) (5)"
* Add the attribute `show-counter` for always hiding the counter ("foo, ... (5)" -> "foo, ...")

I tried to made it so that the defaults are as before. I hope that editing the HTML files was the right way to add the documentation for the new attributes.