### PR TITLE
feat(select): add a custom title instead of 'none selected'

### DIFF
--- a/isteven-multi-select.js
+++ b/isteven-multi-select.js
@@ -58,7 +58,10 @@ angular.module( 'isteven-multi-select', ['ng'] ).directive( 'istevenMultiSelect'
             onSelectNone    : '&',  
 
             // i18n
-            translation     : '='   
+            translation     : '=',
+            
+            // text
+            customTitle     : '@'
         },
         
         /* 
@@ -961,7 +964,7 @@ angular.module( 'isteven-multi-select', ['ng'] ).directive( 'istevenMultiSelect'
                 $scope.lang.selectNone      = $sce.trustAsHtml( $scope.icon.selectNone + '&nbsp;&nbsp;Select None' );
                 $scope.lang.reset           = $sce.trustAsHtml( $scope.icon.reset      + '&nbsp;&nbsp;Reset' );
                 $scope.lang.search          = 'Search...';
-                $scope.lang.nothingSelected = 'None Selected';                
+                $scope.lang.nothingSelected = $scope.customTitle || 'None Selected';                
             }
             $scope.icon.tickMark = $sce.trustAsHtml( $scope.icon.tickMark );
                 


### PR DESCRIPTION
Possibility to add a custom title instead of 'None selected' when no data are selected.
That avoid to put an other label to describe what the select box is for.