### PR TITLE
Set 'max-height' instead of 'height' css property when max-height opt…

### DIFF
--- a/isteven-multi-select.js
+++ b/isteven-multi-select.js
@@ -921,7 +921,7 @@ angular.module( 'isteven-multi-select', ['ng'] ).directive( 'istevenMultiSelect'
             // set max-height property if provided
             if ( typeof attrs.maxHeight !== 'undefined' ) {                
                 var layer = element.children().children().children()[0];
-                angular.element( layer ).attr( "style", "height:" + attrs.maxHeight + "; overflow-y:scroll;" );                                
+                angular.element( layer ).attr( "style", "max-height:" + attrs.maxHeight + "; overflow-y:scroll;" );
             }
 
             // some flags for easier checking            


### PR DESCRIPTION
…ion is specified

Love this library, but ran up on a small display bug where the "max-height" option sets the height of the dropdown instead of the max-height, creating extra space in the dropdown when there are not enough options to fill the height.