### PR TITLE
Added no-labels-label attribute support

### DIFF
--- a/isteven-multi-select.js
+++ b/isteven-multi-select.js
@@ -550,6 +550,9 @@ angular.module( 'isteven-multi-select', ['ng'] ).directive( 'istevenMultiSelect'
                         if (tempMaxLabels > 0) {
                             $scope.varButtonLabel += ', ... ';
                         }
+			else if ( typeof attrs.noLabelsLabel !== 'undefined' && attrs.noLabelsLabel !== '' ) {
+				$scope.varButtonLabel += attrs.noLabelsLabel + ' ';
+			}
                         $scope.varButtonLabel += '(' + $scope.outputModel.length + ')';                        
                     }
                 }


### PR DESCRIPTION
When using max-labels="0" this PR supports an additional attribute named "no-labels-label" to specify a label to be displayed before the selected items count, example:

<div isteven-multi-select....
max-labels="0"
no-labels-label="some label here" 
...></div>

if 3 items are selected, the button will show:  "some label here (3)"