### PR TITLE
Fix race condition on deleting clickedItem

### DIFF
--- a/isteven-multi-select.js
+++ b/isteven-multi-select.js
@@ -439,6 +439,9 @@ angular.module( 'isteven-multi-select', ['ng'] ).directive( 'istevenMultiSelect'
                 clickedItem = angular.copy( item );                                                    
                 if ( clickedItem !== null ) {                        
                     $timeout( function() {
+			if ( clickedItem === null ) {
+		            return;
+			}
                         delete clickedItem[ $scope.indexProperty ];
                         delete clickedItem[ $scope.spacingProperty ];      
                         $scope.onItemClick( { data: clickedItem } );


### PR DESCRIPTION
If you have some code removing all items before the timeout is
able to run, you'll get a nasty TypeError if you don't null check
clickedItem.
