### PR TITLE
Fix removeClass bug

### DIFF
--- a/isteven-multi-select.js
+++ b/isteven-multi-select.js
@@ -695,7 +695,7 @@ angular.module( 'isteven-multi-select', ['ng'] ).directive( 'istevenMultiSelect'
                     }
                 }
 
-                angular.element( checkBoxLayer.previousSibling ).removeClass( 'buttonClicked' );                    
+                angular.element( clickedEl ).removeClass( 'buttonClicked' );                    
                 angular.element( checkBoxLayer ).removeClass( 'show' );
                 angular.element( document ).off( 'click', $scope.externalClickListener ); 
                 angular.element( document ).off( 'keydown', $scope.keyboardListener );                


### PR DESCRIPTION
When clicked out of container, the class *buttonClicked* was not being removed.