### PR TITLE
fix package.json to make it work with webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,10 +2,7 @@
     "name": "isteven-angular-multiselect",
     "version": "v4.0.0",
     "description": "A multi select dropdown directive for AngularJS",
-    "main": [
-        "isteven-multi-select.js",
-        "isteven-multi-select.css"
-    ],
+    "main": "isteven-multi-select.js",
     "repository": {
         "type": "git",
         "url": "https://github.com/isteven/angular-multi-select.git"


### PR DESCRIPTION
This should fix https://github.com/isteven/angular-multi-select/issues/403 - unfortunately the fix described in that issue didn't work for us, this works now. Of course this means that people need to write 2 require lines:

````
require('isteven-angular-multiselect/isteven-multi-select.js');
require('isteven-angular-multiselect/isteven-multi-select.css');
````

or

````
require('isteven-angular-multiselect');
require('isteven-angular-multiselect/isteven-multi-select.css');
````